### PR TITLE
ekyc app crashed can t capture the sefie [18520]

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@ allprojects {
 Update the `build.gradle`(app level).
     
 ```java
+android {
+    ...
+    
+    aaptOptions {
+            noCompress "tflite"
+            noCompress "lite"
+            noCompress "bic"
+        }
+    ...
+}
+
 dependencies {
     implementation 'one.credify.sdk:android-sdk:v0.1.8'
 }
@@ -111,7 +122,10 @@ val params = GetOfferListParam(
 
 CredifySDK.instance.offerApi.getOfferList(params = params, callback: OfferListCallback)
 // OR
-CredifySDK.instance.offerApi.getOfferList(params = params): Observable<List<Offer>>
+CredifySDK.instance.offerApi.getOfferList(params = params): Observable<OfferList>
+
+// NOTE: you need to pass credifyId when you call `CredifySDK.instance.offerApi.showOffer` method
+data class OfferList(val offerList: List<Offer>, val credifyId: String?) : Serializable
 ```
 
 #### Show an offer detail

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ android {
     ...
     
     aaptOptions {
-            noCompress "tflite"
-            noCompress "lite"
-            noCompress "bic"
-        }
+        noCompress "tflite"
+        noCompress "lite"
+        noCompress "bic"
+    }
     ...
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,6 +36,12 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
+
+    aaptOptions {
+        noCompress "tflite"
+        noCompress "lite"
+        noCompress "bic"
+    }
 }
 
 dependencies {


### PR DESCRIPTION
## Description
- Added VNPT configuration to avoid the app crash when doing eKYC.
- Updated VNPT configuration to README file.

## Motivation & Context
Ticket: https://app.shortcut.com/credify/story/18520/android-bug-sdk-ekyc-app-crashed-can-t-capture-the-sefie

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.